### PR TITLE
MBS-8479: Stop stripping iframes in welcomemessage

### DIFF
--- a/classes/enrol_form.php
+++ b/classes/enrol_form.php
@@ -77,7 +77,7 @@ class enrol_form extends moodleform {
 
         if (!empty($instance->customint2)) {
             list($message) = welcomemessage::get_welcomemessage($instance);
-            $mform->addElement('html', format_text($message));
+            $mform->addElement('html', format_text($message, FORMAT_MOODLE, ['noclean' => true]));
         }
         $this->add_action_buttons(false, get_string('enrolme', 'enrol_autoenrol'));
 

--- a/db/access.php
+++ b/db/access.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 $capabilities = array(
 
     'enrol/autoenrol:config'      => array(
+        'riskbitmask' => RISK_XSS | RISK_SPAM,
         'captype'      => 'write',
         'contextlevel' => CONTEXT_COURSE,
         'archetypes'   => array(


### PR DESCRIPTION
Autoenrol Instanz zum Kurs hinzufügen 
-> Option: Einschreiben nach Bestätigung aktivieren
-> in die Begrüßungsmitteilung einen iFrame setzen
-> Show the welcomemessage on confirmation page. auf Ja

=> Iframe sollte auf der Einschreibeseite zu sehen sein.